### PR TITLE
Make `ls` with no args work

### DIFF
--- a/plunchy.py
+++ b/plunchy.py
@@ -91,9 +91,6 @@ class Plunchy(object):
         self.start()
 
     def list(self):
-        if not (self.arg or self.OPTIONS['verbose']):
-            raise ValueError('list|ls [--verbose] [pattern]')
-
         print '\n'.join(self.__plists(self.arg).keys())
 
     def ls(self):


### PR DESCRIPTION
This mimics the behavior of lunchy.

I see no reason to require a --verbose argument to list all services. IMHO, this is not intuitive as the UNIX `ls` command doesn't do this; nor does `lunchy`; nor does `brew ls`.

Before:

```
[marca@marca-mac2 plunchy]$ plunchy ls
ERROR: list|ls [--verbose] [pattern]
[marca@marca-mac2 plunchy]$ plunchy ls '*'
```

After:

```
[marca@marca-mac2 plunchy]$ plunchy ls
homebrew.mxcl.mysql
org.virtualbox.vboxwebsrv
homebrew.mxcl.memcached
com.google.keystone.agent
net.tunnelblick.tunnelblick.LaunchAtLogin
ws.agile.1PasswordAgent
homebrew.mxcl.mongodb
homebrew.mxcl.elasticsearch
homebrew.mxcl.redis
homebrew.mxcl.postgresql
```
