### PR TITLE
Sort output of `list` command

### DIFF
--- a/plunchy.py
+++ b/plunchy.py
@@ -94,7 +94,8 @@ class Plunchy(object):
         if not (self.arg or self.OPTIONS['verbose']):
             raise ValueError('list|ls [--verbose] [pattern]')
 
-        print '\n'.join(self.__plists(self.arg).keys())
+        services = sorted(self.__plists(self.arg).keys())
+        print('\n'.join(services))
 
     def ls(self):
         self.list()


### PR DESCRIPTION
Makes it easier to scan through the list; matches behavior of lunchy.

Before:

```
[marca@marca-mac2 plunchy]$ plunchy list -v
homebrew.mxcl.mysql
org.virtualbox.vboxwebsrv
homebrew.mxcl.memcached
com.google.keystone.agent
net.tunnelblick.tunnelblick.LaunchAtLogin
ws.agile.1PasswordAgent
homebrew.mxcl.mongodb
homebrew.mxcl.elasticsearch
homebrew.mxcl.redis
homebrew.mxcl.postgresql
```

After:

```
[marca@marca-mac2 plunchy]$ plunchy list -v
com.google.keystone.agent
homebrew.mxcl.elasticsearch
homebrew.mxcl.memcached
homebrew.mxcl.mongodb
homebrew.mxcl.mysql
homebrew.mxcl.postgresql
homebrew.mxcl.redis
net.tunnelblick.tunnelblick.LaunchAtLogin
org.virtualbox.vboxwebsrv
ws.agile.1PasswordAgent
```

which matches the output of `lunchy`:

```
[marca@marca-mac2 plunchy]$ lunchy list
com.google.keystone.agent
homebrew.mxcl.elasticsearch
homebrew.mxcl.memcached
homebrew.mxcl.mongodb
homebrew.mxcl.mysql
homebrew.mxcl.postgresql
homebrew.mxcl.redis
net.tunnelblick.tunnelblick.LaunchAtLogin
org.virtualbox.vboxwebsrv
ws.agile.1PasswordAgent
```
