### PR TITLE
Make `edit` require an argument

### DIFF
--- a/plunchy.py
+++ b/plunchy.py
@@ -158,5 +158,8 @@ class Plunchy(object):
             f.close()
 
     def edit(self):
+        if not self.arg:
+            raise ValueError('edit [pattern]')
+
         for path in self.__plists(self.arg).values():
             call([os.getenv('VISUAL', os.getenv('EDITOR', 'vi')), path])


### PR DESCRIPTION
Because if a user does `plunchy edit`, they will be forced to edit every plist and that is tedious if there are a lot of services.
