### PR TITLE
README.md: Add PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # plunchy
 
+[![Latest Version](https://pypip.in/version/plunchy/badge.svg)](https://pypi.python.org/pypi/plunchy/)
+
 `plunchy` is a simple interface into OS X's `launchctl`. It is based on the idea
 behind Mike Perham's [`lunchy`](https://github.com/mperham/lunchy) Ruby script,
 though there are a few small differences between the two:


### PR DESCRIPTION
It's nice IMHO when looking at a repo on GitHub to know that it's mature enough to be on PyPI and that it's just a `pip install` away.

Preview at https://github.com/msabramo/plunchy/blob/patch-1/README.md
