### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/bin/plunchy
+++ b/bin/plunchy
@@ -34,7 +34,7 @@ def main():
     try:
         p.execute()
     except (ValueError, NotImplementedError) as e:
-        print 'ERROR: {}'.format(e)
+        sys.stderr.write('ERROR: {}\n'.format(e))
         sys.exit(1)
 
 

--- a/plunchy.py
+++ b/plunchy.py
@@ -74,7 +74,7 @@ class Plunchy(object):
         for path in plists.values():
             call(['launchctl', 'load', path], stdout=DEVNULL, stderr=DEVNULL)
 
-        print '\n'.join(['Started %s' % p for p in plists.keys()])
+        print('\n'.join(['Started %s' % p for p in plists.keys()]))
 
     def stop(self):
         if not self.arg:
@@ -84,7 +84,7 @@ class Plunchy(object):
         for path in plists.values():
             call(['launchctl', 'unload', path], stdout=DEVNULL, stderr=DEVNULL)
 
-        print '\n'.join(['Stopped %s' % p for p in plists.keys()])
+        print('\n'.join(['Stopped %s' % p for p in plists.keys()]))
 
     def restart(self):
         self.stop()
@@ -94,7 +94,7 @@ class Plunchy(object):
         if not (self.arg or self.OPTIONS['verbose']):
             raise ValueError('list|ls [--verbose] [pattern]')
 
-        print '\n'.join(self.__plists(self.arg).keys())
+        print('\n'.join(self.__plists(self.arg).keys()))
 
     def ls(self):
         self.list()
@@ -123,7 +123,7 @@ class Plunchy(object):
         with open(PLUNCHY_FILE, 'a+') as f:
             f.write('{}\n'.format(self.arg))
 
-        print 'Added {}'.format(self.arg)
+        print('Added {}'.format(self.arg))
 
     def install(self):
         return self.add()
@@ -135,7 +135,7 @@ class Plunchy(object):
         for d in self.__dirs():
             base = os.path.basename(self.arg)
             os.symlink(self.arg, os.path.join(d, base))
-            print 'Installed {} into {} via symlink'.format(self.arg, d)
+            print('Installed {} into {} via symlink'.format(self.arg, d))
             break
 
     def copy(self):
@@ -145,7 +145,7 @@ class Plunchy(object):
         for d in self.__dirs():
             base = os.path.basename(self.arg)
             shutil.copy(self.arg, os.path.join(d, base))
-            print 'Installed {} into {} via copy'.format(self.arg, d)
+            print('Installed {} into {} via copy'.format(self.arg, d))
             break
 
     def show(self):
@@ -153,9 +153,8 @@ class Plunchy(object):
             raise ValueError('show [pattern]')
 
         for base, path in self.__plists(self.arg).items():
-            f = open(path, 'r')
-            print f.read()
-            f.close()
+            with open(path) as f:
+                print(f.read())
 
     def edit(self):
         for path in self.__plists(self.arg).values():


### PR DESCRIPTION
Sample output:

```
$ python3.4 bin/plunchy ls -v
net.tunnelblick.tunnelblick.LaunchAtLogin
homebrew.mxcl.mysql
homebrew.mxcl.elasticsearch
homebrew.mxcl.redis
org.virtualbox.vboxwebsrv
com.google.keystone.agent
homebrew.mxcl.postgresql
homebrew.mxcl.memcached
ws.agile.1PasswordAgent
homebrew.mxcl.mongodb
```
